### PR TITLE
フォーム周りのデザインを調整する

### DIFF
--- a/src/components/ui/form/password-field.tsx
+++ b/src/components/ui/form/password-field.tsx
@@ -12,6 +12,7 @@ export const PasswordField = forwardRef<HTMLInputElement, TextFieldProps>(
         {...props}
         ref={ref}
         type={shouldShowPassword ? "text" : "password"}
+        placeholder="············"
         endAdornment={
           <InputAdornment position="end">
             <IconButton onClick={() => setShouldShowPassword((prev) => !prev)}>

--- a/src/components/ui/form/text-field.tsx
+++ b/src/components/ui/form/text-field.tsx
@@ -24,7 +24,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     return (
       <FormControl error={error} disabled={disabled}>
         <FormLabel>
-          <span>{label}</span>
+          <span className="text-[13px]">{label}</span>
           <OutlinedInput
             ref={ref}
             fullWidth
@@ -34,6 +34,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
               "& .MuiOutlinedInput-input:-webkit-autofill": {
                 boxShadow: "none",
                 backgroundColor: "white",
+                caretColor: "black",
                 "-webkit-text-fill-color": "black",
               },
               "& .MuiOutlineInput-input:webkit-text-fill-color": {},


### PR DESCRIPTION
ログイン・会員登録ページを作成した際、Vuexyのデザイン通りに実装できなかった箇所があるので修正する。

- close #30 

## 対応したこと

- パスワードフィールドのplaceholderを設定
- ラベルのテキストサイズを13pxに調整
- オートフィル時にカーソルが見える様に修正

## 対応しないこと

オートフィル時に背景色が `rgb(232, 240, 254)` になっている。
Vuexyではどういった振る舞いをするか確認できず、user agent stylesheetのため上書きもできない。
よって、対応しないことにした。

## 関連issue

https://github.com/thanklet/mock-dapp-prototype/issues/28
https://github.com/thanklet/mock-dapp-prototype/issues/23
