### PR TITLE
認証実装にともなうpath、userロジックの変更

### DIFF
--- a/src/app/providers/redirect-provider.tsx
+++ b/src/app/providers/redirect-provider.tsx
@@ -22,7 +22,7 @@ export const RedirectProvider = ({ children }: Props) => {
     return <Navigate to={path.get().auth.login} replace={true} />;
   }
   if (user && isAuthPath) {
-    return <Navigate to={path.get().app.userId.dashboard(user.uid)} />;
+    return <Navigate to={path.get().app.dashboard()} />;
   }
   if (!user) {
     return children;

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -39,14 +39,14 @@ const router = createBrowserRouter([
         element: <AppRoot />,
         children: [
           {
-            path: ":userId/dashboard",
+            path: "dashboard",
             lazy: async () => {
               const { DashboardRoute } = await import("./routes/app/dashboard");
               return { Component: DashboardRoute };
             },
           },
           {
-            path: ":userId/thanks/location",
+            path: "thanks/location",
             lazy: async () => {
               const { LocationRoute } = await import(
                 "./routes/app/thanks/location"
@@ -55,7 +55,7 @@ const router = createBrowserRouter([
             },
           },
           {
-            path: ":userId/thanks/send/:receiveUserId",
+            path: "thanks/send/:receiveUserId",
             lazy: async () => {
               const { SendRoute } = await import("./routes/app/thanks/send");
               return { Component: SendRoute };

--- a/src/app/routes/app/dashboard.tsx
+++ b/src/app/routes/app/dashboard.tsx
@@ -1,12 +1,12 @@
+import { useUser } from "@/app/providers/user-provider.tsx";
 import { Head } from "@/components/seo/head";
 import { Dashboard } from "@/features/app/dashboard/components/dashboard";
-import { useParams } from "react-router-dom";
 
 export const DashboardRoute = () => {
-  const { userId } = useParams();
+  const { user } = useUser();
   return (
     <>
-      <Head title={`ユーザー: ${userId}`} />
+      <Head title={`ユーザー: ${user.uid}`} />
       <Dashboard />
     </>
   );

--- a/src/features/app/dashboard/components/dashboard.tsx
+++ b/src/features/app/dashboard/components/dashboard.tsx
@@ -1,3 +1,4 @@
+import { useUser } from "@/app/providers/user-provider";
 import { LinkButton } from "@/components/ui/link-button";
 import { Typography } from "@/components/ui/typography";
 import { useGetDashboard } from "@/features/app/dashboard/api";
@@ -7,7 +8,6 @@ import { CallMade, CallReceived } from "@mui/icons-material";
 import { Box, List, ListItem, Stack } from "@mui/material";
 import { IconHeartCheck } from "@tabler/icons-react";
 import dayjs from "dayjs";
-import { useParams } from "react-router-dom";
 
 const getEmoji = (fileName: string): string => {
   return new URL(`../../../../assets/emoji/${fileName}.svg`, import.meta.url)
@@ -15,10 +15,11 @@ const getEmoji = (fileName: string): string => {
 };
 
 export const Dashboard = () => {
-  const { userId } = useParams();
+  const { user } = useUser();
+  const userId = user.uid;
 
-  const [user, transactionHistories] = useGetDashboard({
-    documentId: userId ?? "",
+  const [userData, transactionHistories] = useGetDashboard({
+    documentId: userId,
   });
   // NOTE: モックなのでユーザー存在しない場合の処理は省略
   // user.data.exists()
@@ -26,22 +27,22 @@ export const Dashboard = () => {
   const buttonData = [
     {
       label: "Thanks",
-      to: path.get().app.userId.thanks.location(userId),
+      to: path.get().app.thanks.location(),
       disabled: false,
     },
     {
       label: "Swap",
-      to: path.get().app.userId.swap(userId),
+      to: path.get().app.swap(),
       disabled: true,
     },
     {
       label: "Staking",
-      to: path.get().app.userId.staking(userId),
+      to: path.get().app.staking(),
       disabled: true,
     },
   ];
 
-  const thanks = user.data.data()?.thanks ?? 0;
+  const thanks = userData.data.data()?.thanks ?? 0;
 
   const histories = transactionHistories.data.docs.map((x) => ({
     id: x.id,

--- a/src/features/app/thanks/location/components/location.tsx
+++ b/src/features/app/thanks/location/components/location.tsx
@@ -1,5 +1,5 @@
+import { useUser } from "@/app/providers/user-provider.tsx";
 import staff1Url from "@/assets/dummy/1.png";
-import staff2Url from "@/assets/dummy/2.png";
 import { Avatar } from "@/components/ui/avatar";
 import { Link } from "@/components/ui/link";
 import { Typography } from "@/components/ui/typography";
@@ -7,7 +7,6 @@ import { path } from "@/utils/path";
 import { Wrapper } from "@googlemaps/react-wrapper";
 import { Box, Stack } from "@mui/material";
 import { useCallback, useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
 import { useGetUsers } from "../api";
 
 const GOOGLE_MAP_API_KEY = import.meta.env.VITE_GOOGLE_MAP_API_KEY as string;
@@ -38,7 +37,8 @@ const POSITIONS = [
 ];
 
 export const Location = () => {
-  const { userId } = useParams();
+  const { user } = useUser();
+  const userId = user.uid;
   const [mapElement, setMapElement] = useState<HTMLDivElement | null>(null);
   const [map, setMap] = useState<google.maps.Map>();
 
@@ -53,8 +53,8 @@ export const Location = () => {
     .map((doc) => ({
       ...doc.data(),
       id: doc.id,
-      // TODO: プロトタイプではユーザーが二人しかいないので、こうしているが本来はimage_pathをそのまま使うだけで表示させたい
-      image_path: doc.data().image_path === "staff1" ? staff1Url : staff2Url,
+      // TODO: プロトタイプではアバター編集機能がないので固定表示
+      image_path: staff1Url,
     }))
     .filter((user) => user.id !== userId);
 
@@ -118,15 +118,15 @@ export const Location = () => {
         }}
       >
         <Stack direction="row" flexWrap="wrap" gap={"20px"}>
-          {users.map((user) => (
+          {users.map((x) => (
             <Link
-              to={path.get().app.userId.thanks.send(userId, user.id)}
-              key={user.id}
+              to={path.get().app.thanks.send(x.id)}
+              key={x.id}
               style={{ textDecoration: "none" }}
             >
-              <Avatar src={user.image_path} sx={{ width: 70, height: 70 }} />
+              <Avatar src={x.image_path} sx={{ width: 70, height: 70 }} />
               <Typography width={"100%"} textAlign="center">
-                {user.name}
+                {x.name}
               </Typography>
             </Link>
           ))}

--- a/src/features/app/thanks/location/components/location.tsx
+++ b/src/features/app/thanks/location/components/location.tsx
@@ -1,5 +1,4 @@
 import { useUser } from "@/app/providers/user-provider.tsx";
-import staff1Url from "@/assets/dummy/1.png";
 import { Avatar } from "@/components/ui/avatar";
 import { Link } from "@/components/ui/link";
 import { Typography } from "@/components/ui/typography";
@@ -53,8 +52,7 @@ export const Location = () => {
     .map((doc) => ({
       ...doc.data(),
       id: doc.id,
-      // TODO: プロトタイプではアバター編集機能がないので固定表示
-      image_path: staff1Url,
+      image_path: doc.data().image_path,
     }))
     .filter((user) => user.id !== userId);
 

--- a/src/features/app/thanks/send/components/send.tsx
+++ b/src/features/app/thanks/send/components/send.tsx
@@ -1,6 +1,4 @@
 import { useUser } from "@/app/providers/user-provider.tsx";
-import staff1Url from "@/assets/dummy/1.png";
-import staff2Url from "@/assets/dummy/2.png";
 import emojiHappyUrl from "@/assets/emoji/happy.svg";
 import emojiHelpfulUrl from "@/assets/emoji/helpful.svg";
 import sentUrl from "@/assets/sent.svg";
@@ -117,10 +115,7 @@ export const Send = () => {
       <Stack alignItems="center" gap={"10px"}>
         <Avatar
           alt={receiveUser.data()?.name}
-          src={
-            // TODO: プロトタイプではユーザーが二人しかいないので、こうしているが本来はimage_pathをそのまま使うだけで表示させたい
-            receiveUser.data()?.image_path === "staff1" ? staff1Url : staff2Url
-          }
+          src={receiveUser.data()?.image_path}
           sx={{
             width: 100,
             height: 100,

--- a/src/features/app/thanks/send/components/send.tsx
+++ b/src/features/app/thanks/send/components/send.tsx
@@ -1,3 +1,4 @@
+import { useUser } from "@/app/providers/user-provider.tsx";
 import staff1Url from "@/assets/dummy/1.png";
 import staff2Url from "@/assets/dummy/2.png";
 import emojiHappyUrl from "@/assets/emoji/happy.svg";
@@ -9,6 +10,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Slider } from "@/components/ui/form/slider";
 import { Popover } from "@/components/ui/popover";
 import { Typography } from "@/components/ui/typography";
+import { path } from "@/utils/path.ts";
 import { Add, Remove } from "@mui/icons-material";
 import { Box, Stack } from "@mui/material";
 import { useQueryClient } from "@tanstack/react-query";
@@ -38,7 +40,10 @@ type Emoji = {
 };
 
 export const Send = () => {
-  const { userId, receiveUserId } = useParams();
+  const { receiveUserId } = useParams();
+  const { user } = useUser();
+  const userId = user.uid;
+
   const [selectedEmoji, setSelectedEmoji] = useState<Emoji>(EMOJI_DATA[0]);
   const [currentThanksValue, setCurrentThanksValue] = useState<string | null>(
     null,
@@ -62,7 +67,7 @@ export const Send = () => {
     }
   };
 
-  const { data: sendUser } = useGetUser({ documentId: userId ?? "" });
+  const { data: sendUser } = useGetUser({ documentId: userId });
   const { data: receiveUser } = useGetUser({ documentId: receiveUserId ?? "" });
   const sendUserThanks = sendUser.data()?.thanks ?? 0;
 
@@ -80,7 +85,7 @@ export const Send = () => {
     await sendThanks({
       transactionHistory: {
         emoji: selectedEmoji.value,
-        send_user_id: userId ?? "",
+        send_user_id: userId,
         receive_user_id: receiveUserId ?? "",
         thanks: thanks,
         created_at: Timestamp.now(),
@@ -294,7 +299,7 @@ export const Send = () => {
                     variant={"outlined"}
                     size={"large"}
                     color="secondary"
-                    href={`/app/${userId}/dashboard`}
+                    href={path.get().app.dashboard()}
                   >
                     dashboard
                   </Button>

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -9,18 +9,13 @@ class Path {
       },
     },
     app: {
-      userId: {
-        dashboard: (userId: string | undefined) => `/app/${userId}/dashboard`,
-        staking: (userId: string | undefined) => `/app/${userId}/staking`,
-        swap: (userId: string | undefined) => `/app/${userId}/swap`,
-        thanks: {
-          location: (userId: string | undefined) =>
-            `/app/${userId}/thanks/location`,
-          send: (
-            userId: string | undefined,
-            receiveUserId: string | undefined,
-          ) => `/app/${userId}/thanks/send/${receiveUserId}`,
-        },
+      dashboard: () => "/app/dashboard",
+      staking: () => "/app/staking",
+      swap: () => "/app/swap",
+      thanks: {
+        location: () => "/app/thanks/location",
+        send: (receiveUserId: string | undefined) =>
+          `/app/thanks/send/${receiveUserId}`,
       },
     },
     profile: {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,7 +10,6 @@
       "@/*": ["src/*"]
     },
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
@@ -18,7 +17,6 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,14 +9,12 @@
       "@/*": ["src/*"]
     },
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## 課題

close #25 

## 対応したこと

- pathからuserIdを削除：認証が実装されたので、pathからuserIdを取得する必要がなくなったので
- アバター画像はcloud firestoreのdocumentに登録されているものを表示