### PR TITLE
FB対応

### DIFF
--- a/src/features/app/thanks/location/components/location.tsx
+++ b/src/features/app/thanks/location/components/location.tsx
@@ -6,6 +6,7 @@ import { path } from "@/utils/path";
 import { Wrapper } from "@googlemaps/react-wrapper";
 import { Box, Stack } from "@mui/material";
 import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useGetUsers } from "../api";
 
 const GOOGLE_MAP_API_KEY = import.meta.env.VITE_GOOGLE_MAP_API_KEY as string;
@@ -36,6 +37,7 @@ const createRandomPosition = () => {
 };
 
 export const Location = () => {
+  const navigate = useNavigate();
   const { user } = useUser();
   const userId = user.uid;
   const [mapElement, setMapElement] = useState<HTMLDivElement | null>(null);
@@ -70,6 +72,7 @@ export const Location = () => {
         const markers = users.map((user) => ({
           position: createRandomPosition(),
           src: user.image_path,
+          userId: user.id,
         }));
 
         for (const marker of markers) {
@@ -78,6 +81,9 @@ export const Location = () => {
           markerElement.style.width = "50px";
           markerElement.style.height = "50px";
           markerElement.style.borderRadius = "50%";
+          markerElement.onclick = () => {
+            navigate(path.get().app.thanks.send(marker.userId));
+          };
           new window.google.maps.marker.AdvancedMarkerElement({
             position: marker.position,
             map: googleMap,
@@ -87,7 +93,7 @@ export const Location = () => {
       }
     };
     initMap();
-  }, [mapElement, map, users]);
+  }, [mapElement, map, users, navigate]);
 
   return (
     <Box sx={{ position: "relative" }}>

--- a/src/features/app/thanks/send/components/send.tsx
+++ b/src/features/app/thanks/send/components/send.tsx
@@ -228,7 +228,7 @@ export const Send = () => {
                           fontWeight={"bold"}
                           mr={"5px"}
                         >
-                          {sendUserThanks}
+                          {sliderValue}
                         </Box>
                         THX
                       </Typography>

--- a/src/features/profile/api/index.ts
+++ b/src/features/profile/api/index.ts
@@ -10,6 +10,22 @@ export const useGetUser = (params: DocRequestParams) => {
   });
 };
 
+export const useGetUsersByIds = ({
+  userIds,
+}: { userIds: DocRequestParams[] }) => {
+  return useSuspenseQuery({
+    queryKey: ["users", userIds],
+    queryFn: async () => {
+      const ids = userIds.map((userId) => userId.documentId);
+      const users = await Promise.all(
+        ids.map((id) => getUser({ documentId: id })),
+      );
+
+      return users;
+    },
+  });
+};
+
 export const usePostUser = () => {
   return useMutation({
     mutationFn: (params: DocRequestParams & { user: User }) =>

--- a/src/models/auth/model.ts
+++ b/src/models/auth/model.ts
@@ -34,6 +34,9 @@ const signUp = async ({
   password,
   username,
 }: Omit<SignUpSchema, "termsAndConditions">) => {
+  // NOTE: Cloud Firestoreの挙動として、同じURLを使うとキャッシュされた同じ画像が返ってくる。
+  //       アバターが全員同じになると見栄えが悪いので、ランダムなIDを含むURLで画像を取得する。
+  const imageId = Math.floor(Math.random() * 1000);
   try {
     const credential = await createUserWithEmailAndPassword(
       auth,
@@ -44,7 +47,7 @@ const signUp = async ({
     createUser({
       documentId: credential.user.uid,
       user: {
-        image_path: "https://picsum.photos/200/300",
+        image_path: `https://picsum.photos/id/${imageId}/200/300`,
         name: username,
         thanks: 0,
         email: credential.user.email || email,


### PR DESCRIPTION
- close #68
- close #70
- close #69 
- close #67 

## スクリーンショット

### トランザクションの送信先・送信元を表示

To: XXX, From: XXXを追加した。

<img width="557" alt="スクリーンショット 2024-11-29 14 06 55" src="https://github.com/user-attachments/assets/7298e533-cf30-49e7-95b9-bb14ef1b6600">

### 地図のアイコンクリックでthanks送信画面に遷移

アイコンをリンクにした。

![](https://i.gyazo.com/1e12c700ed7b814218bf8352e24ba847.gif)

### 会員登録時に設定する画像のURLに画像のIDを設定する (1~1000の乱数)

<img width="775" alt="スクリーンショット 2024-11-29 14 30 39" src="https://github.com/user-attachments/assets/7395a5b0-e56e-46fe-8f10-1212844550af">

### スライダーの値とthanksを連動

![c9f4aa27d848b26be2ecf69b779ffd7d](https://github.com/user-attachments/assets/6c33477f-11f3-45ed-a150-4d038472a968)

<gif>

